### PR TITLE
Фикс загрузок с сайта

### DIFF
--- a/lists/list-general.txt
+++ b/lists/list-general.txt
@@ -46,5 +46,6 @@ ce.ppy.sh
 a.ppy.sh
 s.ppy.sh
 i.ppy.sh
+bm5.ppy.sh
 bm6.ppy.sh
 bm10.ppy.sh

--- a/zapret-osu-youtude-discord/lists/list-general.txt
+++ b/zapret-osu-youtude-discord/lists/list-general.txt
@@ -56,5 +56,6 @@ ce.ppy.sh
 a.ppy.sh
 s.ppy.sh
 i.ppy.sh
+bm5.ppy.sh
 bm6.ppy.sh
 bm10.ppy.sh


### PR DESCRIPTION
Карты на сайте скачиваются с сервера bm5, в данный момент может быть затруднительно скачивать что-либо с сайта без впна. Вообще, вряд ли это можно назвать фиксом, ведь пользователь может сам проверить со страницы загрузок откуда качается файл и внести сервер в оба документа :( Но это для тех, кому лень что-то менять